### PR TITLE
Lock only major version for espresso and rxjava

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -19,8 +19,8 @@ android {
 
 dependencies {
     compile 'com.novoda:rxmocks:0.1.3'
-    compile 'io.reactivex:rxjava:1.0.10'
-    compile 'com.android.support.test.espresso:espresso-core:2.1'
+    compile 'io.reactivex:rxjava:1.+'
+    compile 'com.android.support.test.espresso:espresso-core:2.+'
     testCompile 'org.easytesting:fest-assert-core:2.0M10'
     testCompile 'org.mockito:mockito-core:1.10.19'
 }


### PR DESCRIPTION
I believe a library shouldn't lock the minor and patch version of its dependencies. According to [semantic versioning](http://semver.org/) that shouldn't affect backward compatibility (I guess rxjava and the android dev team respect it).

That makes it easier for the developer to unlock a bugfix for anything being used without being blocked by the project dependencies.